### PR TITLE
Change order in DisputeRequest event

### DIFF
--- a/.vscode/contract-decorators.code-snippets
+++ b/.vscode/contract-decorators.code-snippets
@@ -1,0 +1,118 @@
+{
+	// Place your kleros-v2 workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
+	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+	// Placeholders with the same ids are connected.
+	// Example:
+	// "Print to console": {
+	// 	"scope": "javascript,typescript",
+	// 	"prefix": "log",
+	// 	"body": [
+	// 		"console.log('$1');",
+	// 		"$2"
+	// 	],
+	// 	"description": "Log output to console"
+	// }
+	"Decorator for the Enums / Structs section": {
+		"scope": "solidity",
+		"prefix": "/struct",
+		"body": [
+			"// ************************************* //",
+			"// *         Enums / Structs           * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Storage section": {
+		"scope": "solidity",
+		"prefix": "/stor",
+		"body": [
+			"// ************************************* //",
+			"// *             Storage               * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Events section": {
+		"scope": "solidity",
+		"prefix": "/event",
+		"body": [
+			"// ************************************* //",
+			"// *              Events               * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Function Modifiers section": {
+		"scope": "solidity",
+		"prefix": "/modif",
+		"body": [
+			"// ************************************* //",
+			"// *        Function Modifiers         * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Constructor section": {
+		"scope": "solidity",
+		"prefix": "/constr",
+		"body": [
+			"// ************************************* //",
+			"// *            Constructor            * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Initializer section": {
+		"scope": "solidity",
+		"prefix": "/init",
+		"body": [
+			"// ************************************* //",
+			"// *            Initializer            * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Governance section": {
+		"scope": "solidity",
+		"prefix": "/gov",
+		"body": [
+			"// ************************************* //",
+			"// *             Governance            * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the State Modifiers section": {
+		"scope": "solidity",
+		"prefix": "/state",
+		"body": [
+			"// ************************************* //",
+			"// *         State Modifiers           * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Public Views section": {
+		"scope": "solidity",
+		"prefix": "/view",
+		"body": [
+			"// ************************************* //",
+			"// *           Public Views            * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Internal section": {
+		"scope": "solidity",
+		"prefix": "/intern",
+		"body": [
+			"// ************************************* //",
+			"// *            Internal               * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+}

--- a/contracts/src/CurateV2.sol
+++ b/contracts/src/CurateV2.sol
@@ -432,7 +432,7 @@ contract Curate is IArbitrableV2 {
             ? templateIdRegistration
             : templateIdRemoval;
         uint256 localDisputeID = uint256(keccak256(abi.encodePacked(_itemID, lastRequestIndex)));
-        emit DisputeRequest(arbitrator, localDisputeID, disputeData.disputeID, templateId, "");
+        emit DisputeRequest(arbitrator, disputeData.disputeID, localDisputeID, templateId, "");
 
         if (msg.value > totalCost) {
             payable(msg.sender).send(msg.value - totalCost);

--- a/contracts/src/CurateV2.sol
+++ b/contracts/src/CurateV2.sol
@@ -123,8 +123,8 @@ contract Curate is IArbitrableV2 {
 
     /// @dev Emitted when someone submits a request.
     /// @param _itemID The ID of the affected item.
-    /// @param _localDisputeID Unique dispute identifier within this contract.
-    event RequestSubmitted(bytes32 indexed _itemID, uint256 _localDisputeID);
+    /// @param _requestID Unique dispute identifier within this contract.
+    event RequestSubmitted(bytes32 indexed _itemID, uint256 _requestID);
 
     /// @dev Emitted when the address of the connected Curate contract is set. The Curate is an instance of the Curate contract where each item is the address of a Curate contract related to this one.
     /// @param _connectedTCR The address of the connected Curate. TODO: change TCR mentions.
@@ -350,7 +350,7 @@ contract Curate is IArbitrableV2 {
         request.arbitrationParamsIndex = uint24(arbitrationParamsIndex);
         request.requester = payable(msg.sender);
 
-        emit RequestSubmitted(itemID, getLocalDisputeID(itemID, item.requestCount - 1));
+        emit RequestSubmitted(itemID, getRequestID(itemID, item.requestCount - 1));
 
         if (msg.value > totalCost) {
             payable(msg.sender).send(msg.value - totalCost);
@@ -381,7 +381,7 @@ contract Curate is IArbitrableV2 {
         request.requester = payable(msg.sender);
         request.requestType = RequestType.Clearing;
 
-        emit RequestSubmitted(_itemID, getLocalDisputeID(_itemID, item.requestCount - 1));
+        emit RequestSubmitted(_itemID, getRequestID(_itemID, item.requestCount - 1));
 
         if (msg.value > totalCost) {
             payable(msg.sender).send(msg.value - totalCost);
@@ -433,7 +433,7 @@ contract Curate is IArbitrableV2 {
         uint256 templateId = request.requestType == RequestType.Registration
             ? templateIdRegistration
             : templateIdRemoval;
-        emit DisputeRequest(arbitrator, disputeData.disputeID, getLocalDisputeID(_itemID, lastRequestIndex), templateId, "");
+        emit DisputeRequest(arbitrator, disputeData.disputeID, getRequestID(_itemID, lastRequestIndex), templateId, "");
 
         if (msg.value > totalCost) {
             payable(msg.sender).send(msg.value - totalCost);
@@ -533,7 +533,7 @@ contract Curate is IArbitrableV2 {
     /// @param _itemID The ID of the item.
     /// @param _requestID The ID of the request.
     /// @return Local dispute ID.
-    function getLocalDisputeID(bytes32 _itemID, uint256 _requestID) public pure returns (uint256) {
+    function getRequestID(bytes32 _itemID, uint256 _requestID) public pure returns (uint256) {
         return uint256(keccak256(abi.encodePacked(_itemID, _requestID)));
     }
 

--- a/contracts/src/CurateV2.sol
+++ b/contracts/src/CurateV2.sol
@@ -56,6 +56,7 @@ contract Curate is IArbitrableV2 {
         address payable requester; // Address of the requester.
         // Pack the requester together with the other parameters, as they are written in the same request.
         address payable challenger; // Address of the challenger, if any.
+        // TODO: store templateRegistry in case it's changed?
     }
 
     struct DisputeData {

--- a/contracts/src/CurateView.sol
+++ b/contracts/src/CurateView.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+
+/// @custom:authors: [@unknownunknown1, @mtsalenc*]
+/// @custom:reviewers: []
+/// @custom:auditors: []
+/// @custom:bounties: []
+/// @custom:deployments: []
+
+pragma solidity 0.8.18;
+
+import {Curate, IArbitratorV2} from "./CurateV2.sol";
+
+/// @title CurateView
+/// A view contract to fetch, batch, parse and return Curate contract data efficiently.
+/// This contract includes functions that can halt execution due to out-of-gas exceptions. Because of this it should never be relied upon by other contracts.
+contract CurateView {
+    struct QueryResult {
+        bytes32 ID;
+        Curate.Status status;
+        bool disputed;
+        bool resolved;
+        uint256 disputeID;
+        Curate.Party ruling;
+        address requester;
+        address challenger;
+        address arbitrator;
+        bytes arbitratorExtraData;
+        uint256 submissionTime;
+        uint256 numberOfRequests;
+    }
+
+    struct ArbitrableData {
+        address governor;
+        address arbitrator;
+        bytes arbitratorExtraData;
+        address relayerContract;
+        uint256 submissionBaseDeposit;
+        uint256 removalBaseDeposit;
+        uint256 submissionChallengeBaseDeposit;
+        uint256 removalChallengeBaseDeposit;
+        uint256 challengePeriodDuration;
+        address templateRegistry;
+        uint256 templateIdRegistration;
+        uint256 templateIdRemoval;
+        uint256 arbitrationCost;
+    }
+
+    /// @dev Fetch Curate storage in a single call.
+    /// @param _address The address of the Curate contract to query.
+    /// @return result The latest storage data.
+    function fetchArbitrable(address _address) external view returns (ArbitrableData memory result) {
+        Curate curate = Curate(_address);
+        result.governor = curate.governor();
+        result.arbitrator = address(curate.getArbitrator());
+        result.arbitratorExtraData = curate.getArbitratorExtraData();
+        result.relayerContract = curate.relayerContract();
+        result.submissionBaseDeposit = curate.submissionBaseDeposit();
+        result.removalBaseDeposit = curate.removalBaseDeposit();
+        result.submissionChallengeBaseDeposit = curate.submissionChallengeBaseDeposit();
+        result.removalChallengeBaseDeposit = curate.removalChallengeBaseDeposit();
+        result.challengePeriodDuration = curate.challengePeriodDuration();
+        result.templateRegistry = address(curate.templateRegistry());
+        result.templateIdRegistration = curate.templateIdRegistration();
+        result.templateIdRemoval = curate.templateIdRemoval();
+        result.arbitrationCost = IArbitratorV2(result.arbitrator).arbitrationCost(result.arbitratorExtraData);
+    }
+
+    /// @dev Fetch the latest data on an item in a single call.
+    /// @param _address The address of the Curate contract to query.
+    /// @param _itemID The ID of the item to query.
+    /// @return result The item data.
+    function getItem(address _address, bytes32 _itemID) public view returns (QueryResult memory result) {
+        RequestData memory request = getLatestRequestData(_address, _itemID);
+        result = QueryResult({
+            ID: _itemID,
+            status: request.item.status,
+            disputed: request.disputed,
+            resolved: request.resolved,
+            disputeID: request.disputeID,
+            ruling: request.ruling,
+            requester: request.parties[uint256(Curate.Party.Requester)],
+            challenger: request.parties[uint256(Curate.Party.Challenger)],
+            arbitrator: address(request.arbitrator),
+            arbitratorExtraData: request.arbitratorExtraData,
+            submissionTime: request.submissionTime,
+            numberOfRequests: request.item.numberOfRequests
+        });
+    }
+
+    struct ItemRequest {
+        bool disputed;
+        uint256 disputeID;
+        uint256 submissionTime;
+        bool resolved;
+        address requester;
+        address challenger;
+        address arbitrator;
+        bytes arbitratorExtraData;
+    }
+
+    /// @dev Fetch all requests for an item.
+    /// @param _address The address of the Curate contract to query.
+    /// @param _itemID The ID of the item to query.
+    /// @return requests The items requests.
+    function getItemRequests(address _address, bytes32 _itemID) external view returns (ItemRequest[] memory requests) {
+        Curate curate = Curate(_address);
+        ItemData memory itemData = getItemData(_address, _itemID);
+        requests = new ItemRequest[](itemData.numberOfRequests);
+        for (uint256 i = 0; i < itemData.numberOfRequests; i++) {
+            (
+                bool disputed,
+                uint256 disputeID,
+                uint256 submissionTime,
+                bool resolved,
+                address payable[3] memory parties,
+                ,
+                IArbitratorV2 arbitrator,
+                bytes memory arbitratorExtraData
+            ) = curate.getRequestInfo(_itemID, i);
+
+            // Sort requests by newest first.
+            requests[itemData.numberOfRequests - i - 1] = ItemRequest({
+                disputed: disputed,
+                disputeID: disputeID,
+                submissionTime: submissionTime,
+                resolved: resolved,
+                requester: parties[uint256(Curate.Party.Requester)],
+                challenger: parties[uint256(Curate.Party.Challenger)],
+                arbitrator: address(arbitrator),
+                arbitratorExtraData: arbitratorExtraData
+            });
+        }
+    }
+
+    // Functions and structs below used mainly to avoid stack limit.
+    struct ItemData {
+        Curate.Status status;
+        uint256 numberOfRequests;
+    }
+
+    struct RequestData {
+        ItemData item;
+        bool disputed;
+        uint256 disputeID;
+        uint256 submissionTime;
+        bool resolved;
+        address payable[3] parties;
+        Curate.Party ruling;
+        IArbitratorV2 arbitrator;
+        bytes arbitratorExtraData;
+    }
+
+    /// @dev Fetch data of the an item and return a struct.
+    /// @param _address The address of the Curate contract to query.
+    /// @param _itemID The ID of the item to query.
+    /// @return item The item data.
+    function getItemData(address _address, bytes32 _itemID) public view returns (ItemData memory item) {
+        Curate curate = Curate(_address);
+        (Curate.Status status, uint256 numberOfRequests, ) = curate.getItemInfo(_itemID);
+        item = ItemData(status, numberOfRequests);
+    }
+
+    /// @dev Fetch the latest request of an item.
+    /// @param _address The address of the Curate contract to query.
+    /// @param _itemID The ID of the item to query.
+    /// @return request The request data.
+    function getLatestRequestData(address _address, bytes32 _itemID) public view returns (RequestData memory request) {
+        Curate curate = Curate(_address);
+        ItemData memory item = getItemData(_address, _itemID);
+        (
+            bool disputed,
+            uint256 disputeID,
+            uint256 submissionTime,
+            bool resolved,
+            address payable[3] memory parties,
+            Curate.Party ruling,
+            IArbitratorV2 arbitrator,
+            bytes memory arbitratorExtraData
+        ) = curate.getRequestInfo(_itemID, item.numberOfRequests - 1);
+        request = RequestData(
+            item,
+            disputed,
+            disputeID,
+            submissionTime,
+            resolved,
+            parties,
+            ruling,
+            arbitrator,
+            arbitratorExtraData
+        );
+    }
+}

--- a/contracts/src/CurateView.sol
+++ b/contracts/src/CurateView.sol
@@ -14,6 +14,9 @@ import {Curate, IArbitratorV2} from "./CurateV2.sol";
 /// A view contract to fetch, batch, parse and return Curate contract data efficiently.
 /// This contract includes functions that can halt execution due to out-of-gas exceptions. Because of this it should never be relied upon by other contracts.
 contract CurateView {
+    // ************************************* //
+    // *         Enums / Structs           * //
+    // ************************************* //
     struct QueryResult {
         bytes32 ID;
         Curate.Status status;
@@ -44,6 +47,10 @@ contract CurateView {
         uint256 templateIdRemoval;
         uint256 arbitrationCost;
     }
+
+    // ************************************* //
+    // *           Public Views            * //
+    // ************************************* //
 
     /// @dev Fetch Curate storage in a single call.
     /// @param _address The address of the Curate contract to query.


### PR DESCRIPTION
Changed order of the arguments and also reintroduced evidenceGroupID (renamed to localDisputeID) which was earlier removed from RequestSubmitted event