### PR TITLE
feat: ipfs-migration

### DIFF
--- a/web/src/consts/index.ts
+++ b/web/src/consts/index.ts
@@ -21,57 +21,6 @@ export const ETH_SIGNATURE_REGEX = /^0x[a-fA-F0-9]{130}$/;
 export const DEFAULT_LIST_LOGO = "ipfs://QmWfxEmfEWwM6LDgER2Qp2XZpK1MbDtNp7uGqCS4UPNtgJ/symbol-CURATE.png";
 export const CURATION_POLICY = `${IPFS_GATEWAY}/ipfs/QmWciZMi8mBJg34FapRHK4Yh7a6UqmxrpcKQ3KRNMXzjfx`;
 
-export const lists = [
-  {
-    id: 1,
-    title: "Address Tags",
-    totalItems: 24,
-    chainId: 1,
-    status: Status.RegistrationRequested,
-    logoURI: "https://ipfs.kleros.io//ipfs/QmNNSDkpyDX1wB4NNFdAzaHsJihpvgNVV89zCH8FH9CVAz/ledger-white.png",
-  },
-  {
-    id: 2,
-    title: "Address Tags",
-    totalItems: 24,
-    chainId: 1,
-    status: Status.Registered,
-    logoURI: "https://ipfs.kleros.io//ipfs/QmP1hU1LaheHVGxcSJWg5sC3g25vs5snam3qP1bVVAa7mT/address-tag-2-1.png",
-  },
-  {
-    id: 3,
-    title: "Address Tags",
-    totalItems: 24,
-    chainId: 1,
-    status: Status.ClearingRequested,
-    logoURI: "https://ipfs.kleros.io//ipfs/QmNNSDkpyDX1wB4NNFdAzaHsJihpvgNVV89zCH8FH9CVAz/ledger-white.png",
-  },
-  {
-    id: 4,
-    title: "Address Tags",
-    totalItems: 24,
-    chainId: 1,
-    status: Status.Absent,
-    logoURI: "https://ipfs.kleros.io//ipfs/QmP1hU1LaheHVGxcSJWg5sC3g25vs5snam3qP1bVVAa7mT/address-tag-2-1.png",
-  },
-  {
-    id: 5,
-    title: "Address Tags",
-    totalItems: 24,
-    chainId: 1,
-    status: Status.Absent,
-    logoURI: "https://ipfs.kleros.io//ipfs/QmNNSDkpyDX1wB4NNFdAzaHsJihpvgNVV89zCH8FH9CVAz/ledger-white.png",
-  },
-  {
-    id: 6,
-    title: "Address Tags",
-    totalItems: 24,
-    chainId: 1,
-    status: Status.Absent,
-    logoURI: "https://ipfs.kleros.io//ipfs/QmZPeWnzHGKwvnckQE2QrdRJiUFqQXvQEZGFHdEAh7raHN/fno.png",
-  },
-];
-
 // export const items = [
 //   {
 //     id: 1,

--- a/web/src/pages/SubmitItem/Policy/ReadPolicy.tsx
+++ b/web/src/pages/SubmitItem/Policy/ReadPolicy.tsx
@@ -12,7 +12,7 @@ interface IReadPolicy {}
 const ReadPolicy: React.FC<IReadPolicy> = () => {
   return (
     <StyledA
-      href="https://ipfs.kleros.io//ipfs/QmSxGYpXHBWBGvGnBeZD1pFxh8fRHj4Z7o3fBzrGiqNx4v/tokens-policy.pdf"
+      href="https://cdn.kleros.link/ipfs/QmSxGYpXHBWBGvGnBeZD1pFxh8fRHj4Z7o3fBzrGiqNx4v/tokens-policy.pdf"
       target="_blank"
     >
       → Read the policy here ←

--- a/web/src/pages/SubmitList/ListParameters/ListPreview/ListPageDisplay.tsx
+++ b/web/src/pages/SubmitList/ListParameters/ListPreview/ListPageDisplay.tsx
@@ -34,7 +34,7 @@ const ListPageDisplay: React.FC = () => {
         chainId={421614}
         status={mapFromSubgraphStatus(Status.Registered, false)}
         logoURI={previewData.logoURI}
-        policyURI="https://ipfs.kleros.io//ipfs/QmSxGYpXHBWBGvGnBeZD1pFxh8fRHj4Z7o3fBzrGiqNx4v/tokens-policy.pdf"
+        policyURI="https://cdn.kleros.link/ipfs/QmSxGYpXHBWBGvGnBeZD1pFxh8fRHj4Z7o3fBzrGiqNx4v/tokens-policy.pdf"
       />
     </Container>
   );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update policy URLs to use `cdn.kleros.link` instead of `ipfs.kleros.io` for better reliability and performance.

### Detailed summary
- Updated policy URLs in `ReadPolicy.tsx` and `ListPageDisplay.tsx` to use `cdn.kleros.link`.
- Removed unused list items in `consts/index.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->