### PR TITLE
feat: add externaldisputeid, make dispute null if none instead of zero

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -163,7 +163,9 @@ type Request @entity {
   "True if a dispute was raised."
   disputed: Boolean!
   "ID of the dispute, if any."
-  disputeID: BigInt!
+  disputeID: BigInt
+  "External Dispute ID of the dispute, if any."
+  externalDisputeID: BigInt
   "Time when the request was made. Used to track when the challenge period ends."
   submissionTime: BigInt!
   "True if the request was executed and/or any raised disputes were resolved."

--- a/subgraph/src/Curate.ts
+++ b/subgraph/src/Curate.ts
@@ -284,6 +284,7 @@ export function handleRequestChallenged(event: DisputeRequest): void {
   request.disputed = true;
   request.challenger = ensureUser(event.transaction.from.toHexString()).id;
   request.disputeID = event.params._arbitrableDisputeID;
+  request.externalDisputeID = event.params._externalDisputeID;
 
   request.save();
   item.save();

--- a/subgraph/src/entities/Request.ts
+++ b/subgraph/src/entities/Request.ts
@@ -28,7 +28,6 @@ export function createRequestFromEvent(event: RequestSubmitted): void {
   request.resolutionTime = ZERO;
   request.disputeOutcome = NONE;
   request.resolved = false;
-  request.disputeID = ZERO;
   request.submissionTime = event.block.timestamp;
   request.requestType = item.status;
   request.creationTx = event.transaction.hash;


### PR DESCRIPTION
if approved, to be redeployed onto the multisig subgraph

<!-- start pr-codex -->

## PR-Codex overview
This PR adds functionality to track external dispute IDs in requests and updates related fields in the data model.

### Detailed summary
- Added `externalDisputeID` field to `Request` entity
- Updated `Curate.ts` to include `request.externalDisputeID`
- Updated `Request.ts` to remove `disputeID` and add `externalDisputeID`
- Updated `schema.graphql` to reflect changes in `Request` entity

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `externalDisputeID` field to `Request` type, improving tracking of external disputes.

- **Bug Fixes**
  - Updated `disputeID` field to allow `null` values, enhancing data flexibility.

- **Improvements**
  - Enhanced `handleRequestChallenged` function to handle `externalDisputeID` for better dispute management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->