### PR TITLE
feat(web): redirect-main-curate-item-to-list

### DIFF
--- a/web/src/pages/AllLists/ItemDisplay/index.tsx
+++ b/web/src/pages/AllLists/ItemDisplay/index.tsx
@@ -1,15 +1,25 @@
-import React from "react";
-import { useParams } from "react-router-dom";
+import React, { useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import History from "components/HistoryDisplay";
 import { useItemDetailsQuery } from "queries/useItemDetailsQuery";
 import { useRegistryDetailsQuery } from "queries/useRegistryDetailsQuery";
 import ItemInformationCard from "components/InformationCards/ItemInformationCard";
+import { MAIN_CURATE_ADDRESS } from "src/consts";
 
 const ItemDisplay: React.FC = () => {
   const { itemId } = useParams();
   const [, listAddress] = itemId?.split("@");
+  const navigate = useNavigate();
+
   const { data: itemDetails } = useItemDetailsQuery(itemId);
   const { data: registryDetails } = useRegistryDetailsQuery(listAddress);
+
+  // redirect to list page if the item belongs to main curate
+  useEffect(() => {
+    if (listAddress === MAIN_CURATE_ADDRESS && itemDetails?.item?.key0) {
+      navigate(`/lists/${itemDetails.item.key0}-${itemId}/display/1/desc/all`);
+    }
+  }, [itemId, itemDetails]);
 
   return (
     <div>


### PR DESCRIPTION
This change adds a feature to re-direct items that are lists.
This is only done for lists that are item in the Main curate since we don't have any other list of lists.

Example : 
https://deploy-preview-43--curate-v2.netlify.app/#/lists/item/0x9e4e1d9bfd04530fb0de8df9ba6f7783fd1ce1e8f78b67fb644512017ef2b405@0xad0a109cc2bf4da3a9c505155e15e8c05bd95183

> This is a list that is also an item in the main curate, this will re-direct to the list page

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `ItemDisplay` component by adding a redirect feature for items belonging to the main curate list.

### Detailed summary
- Added `useNavigate` from `react-router-dom`
- Imported `MAIN_CURATE_ADDRESS` constant
- Implemented redirect logic for main curate items
- Utilized `useEffect` for redirect functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation behavior with conditional redirection based on certain criteria in the item display component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->