### PR TITLE
Updated the dispute templates and data mappings

### DIFF
--- a/contracts/deploy/00-curate-v2.ts
+++ b/contracts/deploy/00-curate-v2.ts
@@ -4,55 +4,98 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { HomeChains, isSkipped } from "./utils";
 import { CurateFactory, CurateV2 } from "../typechain-types";
 
-const registrationTemplate = `{
-  "$schema": "../NewDisputeTemplate.schema.json",
-  "title": "Let's do this",
-  "description": "We want to do this: %s",
-  "question": "Does it comply with the policy?",
-  "answers": [
-    {
-      "title": "Yes",
-      "description": "Select this if you agree that it must be done."
-    },
-    {
-      "title": "No",
-      "description": "Select this if you do not agree that it must be done."
-    }
-  ],
-  "policyURI": "/ipfs/Qmdvk...rSD6cE/policy.pdf",
-  "frontendUrl": "https://kleros-v2.netlify.app/#/cases/%s/overview",
+const sharedTemplateProperties = `
+  "policyURI": "{{{policyURI}}}",
+  "frontendUrl": "https://curate-v2.kleros.builders/#/lists/item/{{itemID}}",
+  "arbitrableChainID": "421614",
+  "arbitrableAddress": "{{arbitrableAddress}}",
   "arbitratorChainID": "421614",
   "arbitratorAddress": "0xD08Ab99480d02bf9C092828043f611BcDFEA917b",
-  "category": "Others",
-  "specification": "KIP001",
-  "lang": "en_US"
+  "metadata": {
+    "itemName": "{{itemName}}",
+    "itemDescription": "{{itemDescription}}",
+    "registryTitle": "{{registryTitle}}",
+    "registryDescription": "{{registryDescription}}"
+  },
+  "category": "Curated Lists",
+  "version": "1.0"`;
+
+const registrationTemplate = `{
+  "$schema": "../NewDisputeTemplate.schema.json",
+  "title": "Add a {{itemName}} to {{registryTitle}}",
+  "description": "Someone requested to add an {{itemName}} to {{registryTitle}}",
+  "question": "Does the {{itemName}} comply with the required criteria?",
+  "answers": [
+    {
+      "title": "Yes, Add It",
+      "description": "Select this if you think that the {{itemName}} does comply with the required criteria and should be added."
+    },
+    {
+      "title": "No, Don't Add It",
+      "description": "Select this if you think that the {{itemName}} does not comply with the required criteria and should not be added."
+    }
+  ], ${sharedTemplateProperties}
 }
 `;
 
 const removalTemplate = `{
   "$schema": "../NewDisputeTemplate.schema.json",
-  "title": "Let's do this",
-  "description": "We want to do this: %s",
-  "question": "Should this be removed?",
+  "title": "Remove a {{itemName}} from {{registryTitle}}",
+  "description": "Someone requested to remove a {{itemName}} from {{registryTitle}}",
+  "question": "Does the {{itemName}} comply with the required criteria?",
   "answers": [
     {
-      "title": "Yes",
-      "description": "Select this if you agree that it must be done."
+      "title": "Yes, Remove It",
+      "description": "Select this if you think that the {{itemName}} does not comply with the required criteria and should be removed."
     },
     {
-      "title": "No",
-      "description": "Select this if you do not agree that it must be done."
+      "title": "No, Don't Remove It",
+      "description": "Select this if you think that the {{itemName}} does comply with the required criteria and should not be removed."
     }
-  ],
-  "policyURI": "/ipfs/Qmdvk...rSD6cE/policy.pdf",
-  "frontendUrl": "https://kleros-v2.netlify.app/#/cases/%s/overview",
-  "arbitratorChainID": "421614",
-  "arbitratorAddress": "0xD08Ab99480d02bf9C092828043f611BcDFEA917b",
-  "category": "Others",
-  "specification": "KIP001",
-  "lang": "en_US"
+  ], ${sharedTemplateProperties}
 }
 `;
+
+const dataMappings = `[
+  {
+    "type": "graphql",
+    "endpoint": "https://gateway-arbitrum.network.thegraph.com/api/{{graphApiKey}}/subgraphs/id/H93eWJbDpYKAtkLmsMn7Su3ZLZwAwLN5VoyvQH4NbGAv",
+    "query": "query SearchRequestByDisputeID($externalDisputeID: BigInt!) { requests(where: { externalDisputeID: $externalDisputeID }) { id disputeID submissionTime resolved requester { id } challenger { id } arbitrator arbitratorExtraData deposit disputeOutcome requestType item { id itemID data status registry { id title description policyURI } } } }",
+    "variables": {
+      "externalDisputeID": "{{externalDisputeID}}"
+    },
+    "seek": [
+      "requests[0].item.registry.title",
+      "requests[0].item.registry.description",
+      "requests[0].item.registry.policyURI",
+      "requests[0].item.id",
+      "requests[0].item.data",
+      "requests[0].item.status",
+      "requests[0].item.registry.id"
+    ],
+    "populate": [
+      "registryTitle",
+      "registryDescription",
+      "policyURI",
+      "itemID",
+      "itemData",
+      "itemStatus",
+      "listAddress"
+    ]
+  },
+  {
+    "type": "json",
+    "value": "{{itemData}}",
+    "seek": [
+      "columns[0].label",
+      "columns[0].description"
+    ],
+    "populate": [
+      "itemName",
+      "itemDescription"
+    ]
+  }
+]`;
 
 const listMetadata = `{
   "title": "Kleros Curate",
@@ -107,8 +150,8 @@ const deploy: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     ethers.ZeroAddress, // _connectedTCR
     {
       templateRegistry: disputeTemplateRegistry.address,
-      registrationTemplateParameters: [registrationTemplate, ""],
-      removalTemplateParameters: [removalTemplate, ""],
+      registrationTemplateParameters: [registrationTemplate, dataMappings],
+      removalTemplateParameters: [removalTemplate, dataMappings],
     },
     [fee, fee, fee, fee],
     timeout,

--- a/contracts/deploy/00-curate-v2.ts
+++ b/contracts/deploy/00-curate-v2.ts
@@ -59,7 +59,7 @@ const removalTemplate = `{
 const dataMappings = `[
   {
     "type": "graphql",
-    "endpoint": "https://gateway-arbitrum.network.thegraph.com/api/{{graphApiKey}}/subgraphs/id/H93eWJbDpYKAtkLmsMn7Su3ZLZwAwLN5VoyvQH4NbGAv",
+    "endpoint": "https://gateway-arbitrum.network.thegraph.com/api/{{{graphApiKey}}}/subgraphs/id/H93eWJbDpYKAtkLmsMn7Su3ZLZwAwLN5VoyvQH4NbGAv",
     "query": "query SearchRequestByDisputeID($externalDisputeID: BigInt!) { requests(where: { externalDisputeID: $externalDisputeID }) { id disputeID submissionTime resolved requester { id } challenger { id } arbitrator arbitratorExtraData deposit disputeOutcome requestType item { id itemID data status registry { id title description policyURI } } } }",
     "variables": {
       "externalDisputeID": "{{externalDisputeID}}"

--- a/contracts/deploy/00-curate-v2.ts
+++ b/contracts/deploy/00-curate-v2.ts
@@ -85,7 +85,7 @@ const dataMappings = `[
   },
   {
     "type": "json",
-    "value": "{{itemData}}",
+    "value": "{{{itemData}}}",
     "seek": [
       "columns[0].label",
       "columns[0].description"


### PR DESCRIPTION
Adapted from https://github.com/kleros/curate-v2/issues/33#issuecomment-2174530564, using production subgraph endpoint.

<!-- start pr-codex -->

---

## PR-Codex overview
The PR enhances the Curate V2 deployment by adding shared template properties, updating registration and removal templates, and introducing data mappings for GraphQL and JSON.

### Detailed summary
- Added shared template properties for consistency
- Updated registration and removal templates with dynamic content
- Introduced data mappings for GraphQL and JSON integration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated registration and removal templates with improved titles, descriptions, and questions.
	- Introduced shared template properties for consistency.
	- Added data mappings for better data handling in templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->