### PR TITLE
Refactor/evidence refactors

### DIFF
--- a/contracts/src/CurateV2.sol
+++ b/contracts/src/CurateV2.sol
@@ -392,7 +392,7 @@ contract CurateV2 is IArbitrableV2 {
 
     /// @dev Submit a request to remove an item from the list. Accepts enough ETH to cover the deposit, reimburses the rest.
     /// @param _itemID The ID of the item to remove.
-    /// @param _evidence A link to evidence using its URI.
+    /// @param _evidence Stringified evidence object, example: '{"name" : "Justification", "description" : "Description", "fileURI" : "/ipfs/QmWQV5ZFFhEJiW8Lm7ay2zLxC2XS4wx1b2W7FfdrLMyQQc"}'.
     function removeItem(bytes32 _itemID, string calldata _evidence) external payable {
         Item storage item = items[_itemID];
 
@@ -430,7 +430,7 @@ contract CurateV2 is IArbitrableV2 {
 
     /// @dev Challenges the request of the item. Accepts enough ETH to cover the deposit, reimburses the rest.
     /// @param _itemID The ID of the item which request to challenge.
-    /// @param _evidence A link to evidence using its URI.
+    /// @param _evidence Stringified evidence object, example: '{"name" : "Justification", "description" : "Description", "fileURI" : "/ipfs/QmWQV5ZFFhEJiW8Lm7ay2zLxC2XS4wx1b2W7FfdrLMyQQc"}'.
     function challengeRequest(bytes32 _itemID, string calldata _evidence) external payable {
         Item storage item = items[_itemID];
         require(item.status > Status.Registered, "The item must have a pending request.");

--- a/web/src/components/HistoryDisplay/Party/JustificationDetails.tsx
+++ b/web/src/components/HistoryDisplay/Party/JustificationDetails.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { getIpfsUrl } from "utils/getIpfsUrl";
 import AttachmentIcon from "svgs/icons/attachment.svg";
 import { customScrollbar } from "styles/customScrollbar";
+import { Evidence } from "src/graphql/graphql";
 
 const Container = styled.div`
   width: 100%;
@@ -32,18 +33,14 @@ const StyledA = styled.a`
   }
 `;
 
-export type Justification = {
-  name: string;
-  description: string;
-  fileURI?: string;
-};
+export type Justification = Pick<Evidence, "name" | "description" | "evidence" | "fileURI">;
 
 const JustificationDetails: React.FC<{ justification: Justification }> = ({ justification }) => {
   return (
     <Container>
-      <JustificationTitle>{justification.name}</JustificationTitle>
+      <JustificationTitle>{justification.name ?? "Unable to determine title"}</JustificationTitle>
       <DescriptionContainer>
-        <ReactMarkdown>{justification.description}</ReactMarkdown>
+        <ReactMarkdown>{justification.description ?? "Unable to determine description"}</ReactMarkdown>
       </DescriptionContainer>
       {justification?.fileURI && (
         <StyledA href={getIpfsUrl(justification.fileURI)}>

--- a/web/src/components/HistoryDisplay/Party/JustificationModal.tsx
+++ b/web/src/components/HistoryDisplay/Party/JustificationModal.tsx
@@ -9,8 +9,6 @@ import { mapFromSubgraphStatus } from "components/RegistryCard/StatusBanner";
 
 import { EvidencesQuery, RequestDetailsFragment } from "src/graphql/graphql";
 import { isUndefined } from "src/utils";
-import { getIpfsUrl } from "utils/getIpfsUrl";
-import fetchJsonIpfs from "utils/fetchJsonIpfs";
 import { useEvidences } from "queries/useEvidences";
 
 import Header from "./Header";
@@ -49,31 +47,22 @@ interface IJustificationModal {
 const JustificationModal: React.FC<IJustificationModal> = ({ request, toggleModal, isRemoval }) => {
   const { data: evidenceData, isLoading: isLoadingEvidences } = useEvidences(request.externalDisputeID);
   const [justification, setJustification] = useState<Justification>();
-  const [isLoadingJustification, setIsLoadingJustification] = useState(false);
 
   useEffect(() => {
     if (isUndefined(evidenceData)) return;
-    setIsLoadingJustification(true);
 
-    const uri = getEvidenceUriForRequest(request, evidenceData.evidences, isRemoval);
+    const evidence = getEvidenceForRequest(request, evidenceData.evidences, isRemoval);
 
-    if (!uri) {
-      setIsLoadingJustification(false);
-      return;
+    if (evidence) {
+      setJustification(evidence);
     }
-
-    fetchJsonIpfs(getIpfsUrl(uri))
-      .then((res) => {
-        setJustification(res as Justification);
-      })
-      .finally(() => setIsLoadingJustification(false));
   }, [evidenceData, isRemoval, request]);
 
   return (
     <StyledModal {...{ toggleModal }}>
       <Header text={isRemoval ? "Removal Requested" : "Request Challenged"} />
       <JustificationText>Justification</JustificationText>
-      {isLoadingEvidences || isLoadingJustification ? (
+      {isLoadingEvidences ? (
         <SkeletonJustificationCard />
       ) : justification ? (
         <JustificationDetails {...{ justification }} />
@@ -100,16 +89,16 @@ const JustificationModal: React.FC<IJustificationModal> = ({ request, toggleModa
  * @need this is needed since the removal request might not have the evidence, same for challenge request.
  *       to get the correct evidence for the request, we match the timestamp of the request and evidence,
  *       if both are same , it means the evidence was created in the same block as that request and belongs to the request
- * @returns the evidence uri for the request if it exists, otherwise null
+ * @returns the evidence for the request if it exists, otherwise null
  */
-const getEvidenceUriForRequest = (
+const getEvidenceForRequest = (
   request: RequestDetailsFragment,
   evidences: EvidencesQuery["evidences"],
   isRemoval: boolean
 ) => {
   if (isRemoval) {
     if (evidences.length > 0 && evidences[0].timestamp === request.submissionTime) {
-      return evidences[0].evidence;
+      return evidences[0];
     } else {
       return null;
     }
@@ -118,8 +107,8 @@ const getEvidenceUriForRequest = (
   // in case of challenge either the first or the second one can be the challenge evidence,
   // in case of registration challenge, the 1st one is the challenge evidence,
   // or if the removal request did not have any justification, the 1st one could be the challenge justification
-  if (evidences.length > 0 && evidences[0].timestamp === request.challengeTime) return evidences[0].evidence;
-  if (evidences.length > 1 && evidences[1].timestamp === request.challengeTime) return evidences[1].evidence;
+  if (evidences.length > 0 && evidences[0].timestamp === request.challengeTime) return evidences[0];
+  if (evidences.length > 1 && evidences[1].timestamp === request.challengeTime) return evidences[1];
 
   return null;
 };

--- a/web/src/hooks/queries/useEvidences.ts
+++ b/web/src/hooks/queries/useEvidences.ts
@@ -10,6 +10,9 @@ const evidencesQuery = graphql(`
     evidences(where: { evidenceGroup: $evidenceGroupID }, orderBy: timestamp, orderDirection: asc, first: 2) {
       evidence
       timestamp
+      name
+      description
+      fileURI
     }
   }
 `);


### PR DESCRIPTION
⚠️ Natspec updated in CurateV2.sol, should we deploy it again right now?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates components related to justifications and evidence handling. 

### Detailed summary
- Updated `Justification` type in `JustificationDetails.tsx`
- Refactored logic for fetching evidence in `JustificationModal.tsx`
- Improved handling of evidence in challenge and removal modals

> The following files were skipped due to too many changes: `web/src/components/ActionButton/Modal/RemoveModal.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded evidence data to include `name`, `description`, and `fileURI`.

- **Refactor**
  - Updated logic for handling challenge requests and item removal, improving clarity and maintainability.
  - Simplified evidence handling by directly retrieving evidence objects instead of URIs.

- **Bug Fixes**
  - Improved handling of null values for `name` and `description` properties in justification details.

These changes aim to enhance the user experience by providing more detailed evidence information and streamlining the challenge and removal processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->