### PR TITLE
fix(web): improve onClick functionality

### DIFF
--- a/web/src/layout/Header/DesktopHeader.tsx
+++ b/web/src/layout/Header/DesktopHeader.tsx
@@ -3,7 +3,7 @@ import styled, { css } from "styled-components";
 import { landscapeStyle } from "styles/landscapeStyle";
 import { useToggle } from "react-use";
 import { Link } from "react-router-dom";
-import { useAccount, useChainId } from "wagmi";
+import { useAccount, useNetwork } from "wagmi";
 import { useLockOverlayScroll } from "hooks/useLockOverlayScroll";
 import { DEFAULT_CHAIN } from "consts/chains";
 import KlerosSolutionsIcon from "svgs/menu-icons/kleros-solutions.svg";
@@ -70,14 +70,14 @@ const StyledKlerosSolutionsIcon = styled(KlerosSolutionsIcon)`
   fill: ${({ theme }) => theme.white} !important;
 `;
 
-const ConnectWalletContainer = styled.div<{ isConnected: boolean; isCorrectChain: boolean }>`
+const ConnectWalletContainer = styled.div<{ isConnected: boolean; isDefaultChain: boolean }>`
   label {
     color: ${({ theme }) => theme.white};
   }
 
-  ${({ isConnected, isCorrectChain }) =>
+  ${({ isConnected, isDefaultChain }) =>
     isConnected &&
-    isCorrectChain &&
+    isDefaultChain &&
     css`
       cursor: pointer;
       & > * {
@@ -89,9 +89,9 @@ const DesktopHeader = () => {
   const [isDappListOpen, toggleIsDappListOpen] = useToggle(false);
   const [isHelpOpen, toggleIsHelpOpen] = useToggle(false);
   const [isSettingsOpen, toggleIsSettingsOpen] = useToggle(false);
-  const chainId = useChainId();
+  const { chain } = useNetwork();
   const { isConnected } = useAccount();
-  const isCorrectChain = chainId === DEFAULT_CHAIN;
+  const isDefaultChain = chain?.id === DEFAULT_CHAIN;
   useLockOverlayScroll(isDappListOpen || isHelpOpen || isSettingsOpen);
 
   return (
@@ -118,8 +118,8 @@ const DesktopHeader = () => {
 
         <RightSide>
           <ConnectWalletContainer
-            {...{ isConnected, isCorrectChain }}
-            onClick={isConnected && isCorrectChain ? toggleIsSettingsOpen : undefined}
+            {...{ isConnected, isDefaultChain }}
+            onClick={isConnected && isDefaultChain ? toggleIsSettingsOpen : undefined}
           >
             <ConnectWallet />
           </ConnectWalletContainer>

--- a/web/src/layout/Header/DesktopHeader.tsx
+++ b/web/src/layout/Header/DesktopHeader.tsx
@@ -3,8 +3,9 @@ import styled, { css } from "styled-components";
 import { landscapeStyle } from "styles/landscapeStyle";
 import { useToggle } from "react-use";
 import { Link } from "react-router-dom";
-import { useAccount } from "wagmi";
+import { useAccount, useChainId } from "wagmi";
 import { useLockOverlayScroll } from "hooks/useLockOverlayScroll";
+import { DEFAULT_CHAIN } from "consts/chains";
 import KlerosSolutionsIcon from "svgs/menu-icons/kleros-solutions.svg";
 import DappLogo from "svgs/header/dapp-logo.svg";
 import ConnectWallet from "components/ConnectWallet";
@@ -14,7 +15,6 @@ import Explore from "./navbar/Explore";
 import Menu from "./navbar/Menu";
 import Help from "./navbar/Menu/Help";
 import Settings from "./navbar/Menu/Settings";
-import { Overlay } from "components/Overlay";
 import { PopupContainer } from ".";
 
 const Container = styled.div`
@@ -70,13 +70,14 @@ const StyledKlerosSolutionsIcon = styled(KlerosSolutionsIcon)`
   fill: ${({ theme }) => theme.white} !important;
 `;
 
-const ConnectWalletContainer = styled.div<{ isConnected: boolean }>`
+const ConnectWalletContainer = styled.div<{ isConnected: boolean; isCorrectChain: boolean }>`
   label {
     color: ${({ theme }) => theme.white};
   }
 
-  ${({ isConnected }) =>
+  ${({ isConnected, isCorrectChain }) =>
     isConnected &&
+    isCorrectChain &&
     css`
       cursor: pointer;
       & > * {
@@ -88,7 +89,9 @@ const DesktopHeader = () => {
   const [isDappListOpen, toggleIsDappListOpen] = useToggle(false);
   const [isHelpOpen, toggleIsHelpOpen] = useToggle(false);
   const [isSettingsOpen, toggleIsSettingsOpen] = useToggle(false);
+  const chainId = useChainId();
   const { isConnected } = useAccount();
+  const isCorrectChain = chainId === DEFAULT_CHAIN;
   useLockOverlayScroll(isDappListOpen || isHelpOpen || isSettingsOpen);
 
   return (
@@ -114,7 +117,10 @@ const DesktopHeader = () => {
         </MiddleSide>
 
         <RightSide>
-          <ConnectWalletContainer {...{ isConnected }} onClick={isConnected ? toggleIsSettingsOpen : undefined}>
+          <ConnectWalletContainer
+            {...{ isConnected, isCorrectChain }}
+            onClick={isConnected && isCorrectChain ? toggleIsSettingsOpen : undefined}
+          >
             <ConnectWallet />
           </ConnectWalletContainer>
           <Menu {...{ toggleIsHelpOpen, toggleIsSettingsOpen }} />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds functionality to check if the user is on the default chain before allowing settings access in the `DesktopHeader`. 

### Detailed summary
- Added `useNetwork` import from "wagmi"
- Imported `DEFAULT_CHAIN` from "consts/chains"
- Updated `ConnectWalletContainer` styled component to consider `isDefaultChain`
- Added logic to check if the user is on the default chain before allowing settings access

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `DesktopHeader` component to incorporate network handling, allowing users to see their current blockchain network.
	- Introduced a new prop for the `ConnectWalletContainer` to improve conditional rendering based on network status.

- **Bug Fixes**
	- Improved the logic for opening settings, ensuring that it only activates when users are connected to the wallet and on the default blockchain network, preventing inappropriate actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->