### PR TITLE
fix(web): fix-history-view-for-direct-operations

### DIFF
--- a/web/src/components/HistoryDisplay/index.tsx
+++ b/web/src/components/HistoryDisplay/index.tsx
@@ -1,5 +1,5 @@
 import { Card, CustomTimeline, _TimelineItem1 } from "@kleros/ui-components-library";
-import React from "react";
+import React, { useMemo } from "react";
 import styled, { css, Theme, useTheme } from "styled-components";
 import Header from "./Header";
 import { useItemRequests } from "queries/useRequestsQuery";
@@ -34,6 +34,11 @@ const StyledTimeline = styled(CustomTimeline)`
   }
 `;
 
+const StyledLabel = styled.label`
+  align-self: center;
+  padding-bottom: 32px;
+`;
+
 interface IHistory {
   itemId: string;
   isItem?: boolean;
@@ -41,18 +46,29 @@ interface IHistory {
 
 const History: React.FC<IHistory> = ({ itemId, isItem }) => {
   const theme = useTheme();
-  const { data } = useItemRequests(itemId);
+  const { data, isLoading } = useItemRequests(itemId);
 
-  const items = data?.requests.reduce<_TimelineItem1[]>((acc, request) => {
-    const history = constructItemsFromRequest(request, theme, isItem);
-    acc.push(...history);
-    return acc;
-  }, []);
+  const items = useMemo(
+    () =>
+      data?.requests.reduce<_TimelineItem1[]>((acc, request) => {
+        const history = constructItemsFromRequest(request, theme, isItem);
+        acc.push(...history);
+        return acc;
+      }, []),
+    [data]
+  );
+
+  const Component = useMemo(() => {
+    if (!items || isLoading) return <HistorySkeletonCard />;
+    else if (items.length === 0) return <StyledLabel>No requests yet.</StyledLabel>;
+
+    return <StyledTimeline {...{ items }} />;
+  }, [items, isLoading]);
 
   return (
     <Container>
       <Header />
-      {items ? <StyledTimeline {...{ items }} /> : <HistorySkeletonCard />}
+      {Component}
     </Container>
   );
 };


### PR DESCRIPTION
Fixes the history view for items added/ removed directly.
Since there is no request associated with them, we display "No requests yet."

An alternative would be to make a unique Request entity associated with the direct action, so we don't miss out on showing the history with direct operations

![image](https://github.com/user-attachments/assets/688946bf-f3f0-42b5-b565-44854892dc9f)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to optimize the rendering of history items in the `History` component by implementing memoization and loading state handling.

### Detailed summary
- Added `useMemo` to optimize items creation
- Added loading state handling with `isLoading`
- Updated rendering logic with `Component` based on loading state
- Added `StyledLabel` for empty state message

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved loading state management in the HistoryDisplay component.
	- Enhanced user experience with clear feedback during data loading.

- **Bug Fixes**
	- Optimized data handling to prevent unnecessary recalculations, improving performance.

- **Refactor**
	- Streamlined rendering logic for better responsiveness and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->