### PR TITLE
feat(web): link-to-explorer-for-address-in-account-display

### DIFF
--- a/web/src/layout/Header/navbar/Menu/Settings/General.tsx
+++ b/web/src/layout/Header/navbar/Menu/Settings/General.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
 import { useAccount, useDisconnect } from "wagmi";
 import { Button } from "@kleros/ui-components-library";
@@ -64,13 +64,29 @@ const UserContainer = styled.div`
   gap: 12px;
 `;
 
+const StyledA = styled.a`
+  text-decoration: none;
+  label {
+    cursor: pointer;
+    color: ${({ theme }) => theme.primaryBlue};
+  }
+  :hover {
+    text-decoration: underline;
+  }
+`;
+
 export const DisconnectWalletButton: React.FC = () => {
   const { disconnect } = useDisconnect();
   return <Button text={`Disconnect`} onClick={() => disconnect()} />;
 };
 
 const General: React.FC = () => {
-  const { address } = useAccount();
+  const { address, chain } = useAccount();
+
+  const addressExplorerLink = useMemo(() => {
+    return `${chain?.blockExplorers?.default.url}/address/${address}`;
+  }, [address, chain]);
+
   return (
     <EnsureChainContainer>
       <EnsureChain>
@@ -81,7 +97,9 @@ const General: React.FC = () => {
                 <IdenticonOrAvatar size="48" />
               </StyledAvatarContainer>
               <StyledAddressContainer>
-                <AddressOrName />
+                <StyledA href={addressExplorerLink} rel="noreferrer" target="_blank">
+                  <AddressOrName />
+                </StyledA>
               </StyledAddressContainer>
               <StyledChainContainer>
                 <ChainDisplay />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance the user experience by adding a clickable address link in the Settings General page.

### Detailed summary
- Added a styled anchor tag for address link
- Implemented a disconnect wallet button
- Display address with a link to the blockchain explorer

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a clickable link that allows users to navigate directly to their blockchain address on an explorer site.
	- Enhanced user experience with hover effects on the new link.

- **Improvements**
	- Updated account retrieval to include chain information for better functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->