### PR TITLE
chore(web): show-creator-address-on-list-preview

### DIFF
--- a/web/src/utils/submitListUtils.ts
+++ b/web/src/utils/submitListUtils.ts
@@ -6,6 +6,7 @@ import { TEMPLATE_REGISTRY } from "consts/arbitration";
 import { ItemDetailsFragment, Status } from "src/graphql/graphql";
 import { arbitrum } from "viem/chains";
 import { registrationTemplate, removalTemplate, dataMappings } from "@kleros/curate-v2-templates";
+import { useAccount } from "wagmi";
 
 export const constructListParams = (listData: IListData, listMetadata: IListMetadata) => {
   const baseTemplate = { ...listData } as IList;
@@ -73,6 +74,7 @@ export const retrieveSubmittedListId = (eventLog: Log) =>
   }).args._itemID;
 
 export const constructItemWithMockValues = (data: IListMetadata): ItemDetailsFragment => {
+  const { address } = useAccount();
   const props: ListField & { value: ReturnType<typeof getMockValueForType> }[] = [];
   for (const column of data.columns) {
     props.push({ ...column, value: getMockValueForType(column.type) });
@@ -83,7 +85,7 @@ export const constructItemWithMockValues = (data: IListMetadata): ItemDetailsFra
     status: Status.RegistrationRequested,
     disputed: false,
     registerer: {
-      id: getMockValueForType("address") as string,
+      id: address as string,
     },
     props,
   };

--- a/web/src/utils/submitListUtils.ts
+++ b/web/src/utils/submitListUtils.ts
@@ -85,7 +85,7 @@ export const constructItemWithMockValues = (data: IListMetadata): ItemDetailsFra
     status: Status.RegistrationRequested,
     disputed: false,
     registerer: {
-      id: address as string,
+      id: address ?? (getMockValueForType("address") as string),
     },
     props,
   };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the use of the `useAccount` hook from `wagmi` to retrieve the user's account address, which enhances the functionality of the `constructItemWithMockValues` function by ensuring that the `registerer.id` can utilize the current user's address.

### Detailed summary
- Added `useAccount` import from `wagmi`.
- Updated `constructItemWithMockValues` to retrieve `address` from `useAccount`.
- Changed `registerer.id` to use the current user's `address`, falling back to a mock value if not available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The system now uses your connected account address when available, instead of a mock address, for the registerer ID in relevant actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->