### PR TITLE
feat: improve registries grid responsiveness

### DIFF
--- a/web/src/pages/AllLists/RegistriesFetcher.tsx
+++ b/web/src/pages/AllLists/RegistriesFetcher.tsx
@@ -11,7 +11,7 @@ import { useRegistryDetailsQuery } from "hooks/queries/useRegistryDetailsQuery";
 import { List_filters } from "consts/filters";
 import { sortRegistriesByIds } from "utils/sortRegistriesByIds";
 import { MAIN_CURATE_ADDRESS } from "src/consts";
-import { LG_BREAKPOINT } from "src/styles/breakpoints";
+import { LG_BREAKPOINT, SM_BREAKPOINT } from "src/styles/breakpoints";
 
 const RegistriesFetcher: React.FC = () => {
   const { page, order, filter } = useParams();
@@ -21,7 +21,7 @@ const RegistriesFetcher: React.FC = () => {
   const navigate = useNavigate();
   const { width } = useWindowSize();
   const location = useListRootPath();
-  const registriesPerPage = width > LG_BREAKPOINT ? 9 : 3;
+  const registriesPerPage = width > LG_BREAKPOINT ? 9 : width > SM_BREAKPOINT ? 6 : 3;
   const pageNumber = parseInt(page ?? "1", 10);
   const registrySkip = registriesPerPage * (pageNumber - 1);
 

--- a/web/src/styles/breakpoints.ts
+++ b/web/src/styles/breakpoints.ts
@@ -1,1 +1,2 @@
 export const LG_BREAKPOINT = 900;
+export const SM_BREAKPOINT = 600;


### PR DESCRIPTION
Resolves #91.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new small breakpoint constant and modifies the logic for determining the number of registries displayed per page based on the window width.

### Detailed summary
- Added `SM_BREAKPOINT` constant with a value of `600` in `web/src/styles/breakpoints.ts`.
- Updated import statement in `web/src/pages/AllLists/RegistriesFetcher.tsx` to include `SM_BREAKPOINT`.
- Changed the `registriesPerPage` calculation to consider `SM_BREAKPOINT`, adjusting the display logic for smaller widths.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registries list now adapts to your screen size, displaying between 3-9 items per page for optimized viewing across all devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->