### PR TITLE
chore(deps): bump @kleros/kleros-app to version 2.2.2

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@cyntler/react-doc-viewer": "^1.17.0",
     "@kleros/curate-v2-templates": "workspace:^",
-    "@kleros/kleros-app": "^2.0.2",
+    "@kleros/kleros-app": "^2.2.2",
     "@kleros/ui-components-library": "^3.6.0",
     "@reown/appkit": "^1.6.6",
     "@reown/appkit-adapter-wagmi": "^1.6.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5543,7 +5543,7 @@ __metadata:
     "@graphql-codegen/client-preset": "npm:^4.2.0"
     "@kleros/curate-v2-templates": "workspace:^"
     "@kleros/curate-v2-tsconfig": "workspace:^"
-    "@kleros/kleros-app": "npm:^2.0.2"
+    "@kleros/kleros-app": "npm:^2.2.2"
     "@kleros/kleros-v2-contracts": "npm:^0.10.0"
     "@kleros/ui-components-library": "npm:^3.6.0"
     "@reown/appkit": "npm:^1.6.6"
@@ -5603,20 +5603,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kleros/kleros-app@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@kleros/kleros-app@npm:2.0.2"
+"@kleros/kleros-app@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@kleros/kleros-app@npm:2.2.2"
   dependencies:
     jose: "npm:^5.9.6"
   peerDependencies:
-    "@tanstack/react-query": ^5.59.20
+    "@tanstack/react-query": ^5.69.0
     graphql: ^16.9.0
     graphql-request: ^7.1.2
     react: ^18.3.1
     react-dom: ^18.3.1
-    viem: ^2.21.42
-    wagmi: ^2.13.0
-  checksum: 89cf0536fed4bbb887772daa529d7cad209cea0e5105bcd366fe5e4bc7c5c14fca21aa201ba4d848c7e8addd3fc4921ac54e237afe2a5b7224c9cd219f72e08b
+    viem: ^2.24.1
+    wagmi: ^2.14.15
+  checksum: 088d84a60eeb2d54dbbc0fda2f6212b6356f64aa42fa73be4939f4a52bda406c6192bffd827079d206e7ff276e720987c001915598a5080e0b244015df12ae43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves #99.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@kleros/kleros-app` package from `^2.0.2` to `^2.2.2` in both `package.json` and `yarn.lock`. Additionally, it modifies the peer dependency version of `@tanstack/react-query` from `^5.59.20` to `^5.69.0` and updates the versions of `viem` and `wagmi`.

### Detailed summary
- Updated `@kleros/kleros-app` from `^2.0.2` to `^2.2.2` in `package.json` and `yarn.lock`.
- Changed `@tanstack/react-query` peer dependency from `^5.59.20` to `^5.69.0`.
- Updated `viem` from `^2.21.42` to `^2.24.1`.
- Updated `wagmi` from `^2.13.0` to `^2.14.15`.
- Updated checksum in `yarn.lock`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->