### PR TITLE
chore: basic-documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,32 @@
 
 # curate-v2
 
-Setup:
+Decentralized curation protocol for lists on-chain.
+
+> Types and schemas may change — product under development. See **[docs/README.md](docs/README.md)** for types, schemas, and templates.
+
+## Setup
 
 ```bash
 yarn
 ```
 
-The frontend is located in the `web` folder
+## Development
+
+**Frontend**
 
 ```bash
-cd web
-yarn && yarn start
+cd web && yarn start
 ```
 
+## Project structure
+
+```
+contracts/   # CurateV2, CurateFactory
+subgraph/    # Subgraph indexing
+templates/   # Dispute templates
+web/         # Frontend
+docs/        # Types, schemas, API reference
+```
+
+For deployment, env vars, and more: see `contracts/README.md` and `web/` package scripts.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cd web && yarn start
 
 ## Project structure
 
-```
+```text
 contracts/   # CurateV2, CurateFactory
 subgraph/    # Subgraph indexing
 templates/   # Dispute templates

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,126 @@
+## Core Types
+
+> **Note:** This product is under development. Types and schemas may change between versions.
+
+### How they relate
+
+**List Metadata** is defined when you _create a list_. It describes the list and, crucially, defines the **schema** (columns) that every item in that list must follow.
+
+**Curate Item** is the format used when you _submit an item_ to a list. Each item's `columns` must match the list's schema, and `values` holds the actual data for each column.
+
+```
+List created → List metadata (JSON string) emitted via ListMetadataSet
+                         ↓
+User submits item → CurateItem (JSON string) passed to contract
+                         ↓
+Contract emits JSON in events; subgraph parses into Registry + Item + ItemProp
+```
+
+---
+
+### List Metadata
+
+Defined when creating a list. Stored as JSON string; the contract emits it via `ListMetadataSet`. The subgraph parses the JSON into `Registry` + `FieldProp` entities.
+
+| Field                        | Purpose                                                                                        |
+| ---------------------------- | ---------------------------------------------------------------------------------------------- |
+| `title`, `description`       | List display info                                                                              |
+| `itemName`, `itemNamePlural` | Singular/plural labels for items (e.g. "Token" / "Tokens") — used in UI and dispute templates  |
+| `logoURI`, `policyURI`       | Optional links                                                                                 |
+| `isListOfLists`              | When `true`, items are sub-list contract addresses                                             |
+| `columns`                    | **Schema for all items** — each item in this list must have these columns with matching labels |
+
+```typescript
+interface ListMetadata {
+  title: string;
+  description: string;
+  itemName: string;
+  itemNamePlural: string;
+  logoURI?: string;
+  policyURI?: string;
+  isListOfLists?: boolean;
+  columns: Array<{
+    label: string;
+    description: string;
+    type: string; // e.g. "text", "address", "url"
+    isIdentifier?: boolean; // up to 5; used for search indexing (key0..key4)
+  }>;
+}
+```
+
+---
+
+### Curate Item
+
+Format for submitting an item to a list. The item's `columns` must match the list's `columns` schema. The contract receives a JSON string and emits it in `NewItem` events. The subgraph parses the JSON into `Item` + `ItemProp` entities.
+
+| Field     | Purpose                                                                 |
+| --------- | ----------------------------------------------------------------------- |
+| `columns` | Must mirror the list's columns (same labels, types). Defines structure. |
+| `values`  | Actual data: `{ [column.label]: string }`                               |
+
+```typescript
+interface CurateItem {
+  columns: Array<{
+    label: string;
+    description: string;
+    type: string;
+    isIdentifier?: boolean;
+  }>;
+  values: Record<string, string>; // key = column label, value = string
+}
+```
+
+**Example** (for a list whose schema has `Name` and `URL` columns):
+
+```json
+{
+  "columns": [
+    { "label": "Name", "description": "Item name", "type": "text", "isIdentifier": true },
+    { "label": "URL", "description": "Item URL", "type": "url" }
+  ],
+  "values": {
+    "Name": "Example",
+    "URL": "https://example.com"
+  }
+}
+```
+
+- `itemID` = `keccak256(abi.encodePacked(string))` — hash of the exact string passed to `addItem`/`addItemDirectly`
+- Entity ID format: `<itemID>@<listAddress>`
+
+---
+
+### Item Status
+
+| Status                  | Meaning                          |
+| ----------------------- | -------------------------------- |
+| `absent`                | Not on list, no pending requests |
+| `registered`            | On list, no pending requests     |
+| `registrationRequested` | Pending add request              |
+| `clearingRequested`     | Pending removal request          |
+
+---
+
+## Dispute Templates
+
+Located in `templates/` (`@kleros/curate-v2-templates`).
+
+- **Registration:** disputing add requests — "Does the {{itemName}} comply?" → Yes, Add It / No, Don't Add It
+- **Removal:** disputing remove requests — same question → Yes, Remove It / No, Don't Remove It
+- **Data mappings:** GraphQL + JSON to populate placeholders from subgraph and item JSON
+
+---
+
+## Quick Reference
+
+| Concept               | Location                                         |
+| --------------------- | ------------------------------------------------ |
+| Item schema           | `web/src/types/CurateItem.ts`                    |
+| List metadata schema  | `web/src/types/ListMetadata.ts`                  |
+| Subgraph schema       | `subgraph/schema.graphql`                        |
+| Dispute templates     | `templates/index.ts`                             |
+| Item parsing logic    | `subgraph/src/entities/Item.ts`                  |
+| List metadata parsing | `subgraph/src/Curate.ts` (handleListMetadataSet) |
+
+**Schemas may change.** Validate at runtime; prefer the Zod schemas in `web/src/types/` when available.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 
 **Curate Item** is the format used when you _submit an item_ to a list. Each item's `columns` must match the list's schema, and `values` holds the actual data for each column.
 
-```
+```text
 List created → List metadata (JSON string) emitted via ListMetadataSet
                          ↓
 User submits item → CurateItem (JSON string) passed to contract


### PR DESCRIPTION
Adds basic documentation to keep track of types and schema.

Will be made exhaustive later

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the documentation for the `curate-v2` project, providing clearer setup instructions, detailed information on core types, schemas, and project structure, as well as dispute templates.

### Detailed summary
- Updated the `README.md` to include a decentralized curation protocol description.
- Added sections for setup, development, and project structure.
- Introduced core types and their relationships in `docs/README.md`.
- Detailed `ListMetadata` and `CurateItem` interfaces.
- Specified item status definitions and dispute templates.
- Provided quick reference links to schemas and parsing logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced setup content with a decentralized protocol overview, added frontend development instructions, project structure, and deployment notes.
  * Added detailed docs for core types and data flows: list metadata, curate items, item status states, dispute templates, quick references, and guidance on runtime validation and schema evolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->